### PR TITLE
Add about redirect and registry

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -88,6 +88,10 @@ const config: Config = {
             to: '/about/contributing',
             from: '/CONTRIBUTING',
           },
+          {
+            to: '/about/about-us',
+            from: '/about',
+          },
         ],
       },
     ],
@@ -122,6 +126,11 @@ const config: Config = {
           position: 'left',
           label: 'RFC',
           docsPluginId: 'about',
+        },
+        {
+          to: '/registry',
+          position: 'left',
+          label: 'Registry',
         },
         {
           type: 'docsVersionDropdown',

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "clsx": "^2.0.0",
         "prism-react-renderer": "^2.3.0",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "zod": "^4.0.14"
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "3.8.1",
@@ -17502,6 +17503,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.14.tgz",
+      "integrity": "sha512-nGFJTnJN6cM2v9kXL+SOBq3AtjQby3Mv5ySGFof5UGRHrRioSJ5iG680cYNjE/yWk671nROcpPj4hAS8nyLhSw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "zod": "^4.0.14"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.8.1",

--- a/src/pages/registry.module.css
+++ b/src/pages/registry.module.css
@@ -1,0 +1,216 @@
+.registryContainer {
+  min-height: 70vh;
+  padding: 2rem 0;
+  background-color: #000000;
+  color: #ffffff;
+}
+
+.header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.header h1 {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+  color: #ffffff;
+}
+
+.header p {
+  font-size: 1.2rem;
+  color: #cccccc;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.searchContainer {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 3rem;
+}
+
+.searchInput {
+  width: 100%;
+  max-width: 500px;
+  padding: 1rem 1.5rem;
+  font-size: 1.1rem;
+  border: 2px solid #333333;
+  border-radius: 10px;
+  background-color: #111111;
+  color: #ffffff;
+  outline: none;
+  transition: border-color 0.3s ease;
+}
+
+.searchInput:focus {
+  border-color: #ffffff;
+}
+
+.searchInput::placeholder {
+  color: #888888;
+}
+
+.providersGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+  gap: 2rem;
+  margin-top: 2rem;
+}
+
+.providerCard {
+  background-color: #111111;
+  border: 1px solid #333333;
+  border-radius: 12px;
+  padding: 1.5rem;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.providerCard:hover {
+  transform: translateY(-4px);
+  border-color: #666666;
+}
+
+.cardHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid #333333;
+}
+
+.cardHeaderLeft {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: flex-start;
+}
+
+.cardFooter {
+  border-top: 1px solid #333333;
+  padding-top: 1rem;
+  margin-top: 1rem;
+  display: flex;
+  justify-content: center;
+}
+
+.copyButton {
+  background-color: #333333;
+  color: #ffffff;
+  border: 1px solid #666666;
+  border-radius: 6px;
+  padding: 0.5rem 1rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  white-space: nowrap;
+}
+
+.copyButton:hover {
+  background-color: #444444;
+  border-color: #888888;
+}
+
+.copyButton:active {
+  transform: translateY(1px);
+}
+
+.downloadButton {
+  background-color: #2d5a27;
+  color: #ffffff;
+  border: 1px solid #4a8c3a;
+  border-radius: 6px;
+  padding: 0.75rem 1.5rem;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  white-space: nowrap;
+  min-width: 150px;
+}
+
+.downloadButton:hover:not(:disabled) {
+  background-color: #3a6b33;
+  border-color: #5ba048;
+}
+
+.downloadButton:active:not(:disabled) {
+  transform: translateY(1px);
+}
+
+.downloadButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.providerName {
+  font-size: 1.3rem;
+  font-weight: 600;
+  margin: 0;
+  color: #ffffff;
+}
+
+.providerType {
+  background-color: #333333;
+  color: #ffffff;
+  padding: 0.3rem 0.8rem;
+  border-radius: 20px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  width: fit-content;
+  display: inline-block;
+}
+
+.cardContent {
+  color: #cccccc;
+}
+
+.cardContent p {
+  margin: 0.5rem 0;
+  font-size: 0.95rem;
+}
+
+.cardContent strong {
+  color: #ffffff;
+}
+
+.cardContent a {
+  color: #ffffff;
+  text-decoration: underline;
+  word-break: break-all;
+}
+
+.cardContent a:hover {
+  color: #cccccc;
+}
+
+.loading {
+  text-align: center;
+  padding: 4rem 0;
+  font-size: 1.2rem;
+  color: #cccccc;
+}
+
+.noResults {
+  grid-column: 1 / -1;
+  text-align: center;
+  padding: 4rem 0;
+  font-size: 1.2rem;
+  color: #cccccc;
+}
+
+@media (max-width: 768px) {
+  .providersGrid {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+  
+  .searchInput {
+    margin: 0 1rem;
+  }
+  
+  .header h1 {
+    font-size: 2rem;
+  }
+}

--- a/src/pages/registry.tsx
+++ b/src/pages/registry.tsx
@@ -1,0 +1,203 @@
+import React, { useState, useEffect } from 'react';
+import type { ReactNode } from 'react';
+import Layout from '@theme/Layout';
+import styles from './registry.module.css';
+
+interface Provider {
+  name: string;
+  provider_type: string;
+  [key: string]: any;
+}
+
+function ProviderCard({ provider }: { provider: Provider }) {
+  const [copySuccess, setCopySuccess] = useState(false);
+  const [downloadLoading, setDownloadLoading] = useState(false);
+
+  const copyToClipboard = async () => {
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(provider, null, 2));
+      setCopySuccess(true);
+      setTimeout(() => setCopySuccess(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy: ', err);
+    }
+  };
+
+  const downloadManual = async () => {
+    if (provider.provider_type !== 'text' || !provider.file_path) return;
+    
+    setDownloadLoading(true);
+    try {
+      // Extract filename from file_path properly handling any path format
+      const filename = provider.file_path.split(/[\\\/]/).pop() || provider.file_path;
+      const response = await fetch(`/manuals/${filename}`);
+      
+      if (!response.ok) {
+        throw new Error(`Failed to download: ${response.statusText}`);
+      }
+      
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      window.URL.revokeObjectURL(url);
+      document.body.removeChild(a);
+    } catch (err) {
+      console.error('Failed to download manual:', err);
+      alert('Failed to download manual file');
+    } finally {
+      setDownloadLoading(false);
+    }
+  };
+
+  const formatPropertyName = (key: string): string => {
+    return key
+      .split('_')
+      .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(' ');
+  };
+
+  const renderPropertyValue = (key: string, value: any): ReactNode => {
+    if (value === null || value === undefined) return null;
+    
+    if (typeof value === 'boolean') {
+      return <span>{value ? 'Yes' : 'No'}</span>;
+    }
+    
+    if (typeof value === 'object') {
+      if (Array.isArray(value)) {
+        return <span>{value.join(', ')}</span>;
+      }
+      return <span>{JSON.stringify(value, null, 2)}</span>;
+    }
+    
+    if (typeof value === 'string' && (value.startsWith('http://') || value.startsWith('https://'))) {
+      return <a href={value} target="_blank" rel="noopener noreferrer">{value}</a>;
+    }
+    
+    return <span>{value.toString()}</span>;
+  };
+
+  const renderProviderDetails = () => {
+    const excludedKeys = ['name', 'provider_type'];
+    
+    return Object.entries(provider)
+      .filter(([key]) => !excludedKeys.includes(key))
+      .map(([key, value]) => {
+        if (value === null || value === undefined) return null;
+        
+        return (
+          <p key={key}>
+            <strong>{formatPropertyName(key)}:</strong> {renderPropertyValue(key, value)}
+          </p>
+        );
+      })
+      .filter(Boolean);
+  };
+
+  return (
+    <div className={styles.providerCard}>
+      <div className={styles.cardHeader}>
+        <div className={styles.cardHeaderLeft}>
+          <h3 className={styles.providerName}>{provider.name}</h3>
+          <span className={styles.providerType}>{provider.provider_type}</span>
+        </div>
+        <button 
+          className={styles.copyButton}
+          onClick={copyToClipboard}
+          title="Copy JSON to clipboard"
+        >
+          {copySuccess ? '✓ Copied!' : '📋 Copy'}
+        </button>
+      </div>
+      <div className={styles.cardContent}>
+        {renderProviderDetails()}
+      </div>
+      {provider.provider_type === 'text' && provider.file_path && (
+        <div className={styles.cardFooter}>
+          <button 
+            className={styles.downloadButton}
+            onClick={downloadManual}
+            disabled={downloadLoading}
+            title="Download manual JSON file"
+          >
+            {downloadLoading ? '⏳ Loading...' : '📄 Download Manual'}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function Registry(): ReactNode {
+  const [providers, setProviders] = useState<Provider[]>([]);
+  const [filteredProviders, setFilteredProviders] = useState<Provider[]>([]);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('/providers.json')
+      .then(response => response.json())
+      .then((data: Provider[]) => {
+        setProviders(data);
+        setFilteredProviders(data);
+        setLoading(false);
+      })
+      .catch(error => {
+        console.error('Error loading providers:', error);
+        setLoading(false);
+      });
+  }, []);
+
+  useEffect(() => {
+    const filtered = providers.filter(provider =>
+      provider.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      provider.provider_type.toLowerCase().includes(searchTerm.toLowerCase())
+    );
+    setFilteredProviders(filtered);
+  }, [searchTerm, providers]);
+
+  return (
+    <Layout
+      title="Provider Registry"
+      description="Browse available UTCP providers">
+      <div className={styles.registryContainer}>
+        <div className="container">
+          <div className={styles.header}>
+            <h1>Provider Registry</h1>
+            <p>Discover and explore available UTCP providers</p>
+          </div>
+          
+          <div className={styles.searchContainer}>
+            <input
+              type="text"
+              placeholder="Search providers..."
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              className={styles.searchInput}
+            />
+          </div>
+
+          {loading ? (
+            <div className={styles.loading}>Loading providers...</div>
+          ) : (
+            <div className={styles.providersGrid}>
+              {filteredProviders.length > 0 ? (
+                filteredProviders.map((provider, index) => (
+                  <ProviderCard key={index} provider={provider} />
+                ))
+              ) : (
+                <div className={styles.noResults}>
+                  No providers found matching "{searchTerm}"
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </Layout>
+  );
+}

--- a/src/pages/registry.tsx
+++ b/src/pages/registry.tsx
@@ -187,7 +187,7 @@ export default function Registry(): ReactNode {
             <div className={styles.providersGrid}>
               {filteredProviders.length > 0 ? (
                 filteredProviders.map((provider, index) => (
-                  <ProviderCard key={index} provider={provider} />
+                  <ProviderCard key={provider.name} provider={provider} />
                 ))
               ) : (
                 <div className={styles.noResults}>

--- a/static/manuals/newsapi_manual.json
+++ b/static/manuals/newsapi_manual.json
@@ -20,7 +20,7 @@
           },
           "sources": {
             "type": "string",
-            "description": "A comma-seperated string of identifiers (maximum 20) for the news sources or blogs you want headlines from."
+          "description": "A comma-separated string of identifiers (maximum 20) for the news sources or blogs you want headlines from."
           },
           "domains": {
             "type": "string",

--- a/static/manuals/newsapi_manual.json
+++ b/static/manuals/newsapi_manual.json
@@ -1,0 +1,252 @@
+{
+  "version": "1.0",
+  "tools": [
+    {
+      "name": "everything_get",
+      "description": "Search through millions of articles from over 150,000 large and small news sources and blogs. This endpoint suits article discovery and analysis. It requires either a search query, a source, or a domain.",
+      "tags": [
+        "articles"
+      ],
+      "inputs": {
+        "type": "object",
+        "properties": {
+          "q": {
+            "type": "string",
+            "description": "Keywords or phrases to search for in the article title and body. Advanced search is supported. Max length: 500 chars."
+          },
+          "searchIn": {
+            "type": "string",
+            "description": "The fields to restrict your q search to. Possible options: title, description, content. Multiple options can be specified by separating them with a comma."
+          },
+          "sources": {
+            "type": "string",
+            "description": "A comma-seperated string of identifiers (maximum 20) for the news sources or blogs you want headlines from."
+          },
+          "domains": {
+            "type": "string",
+            "description": "A comma-seperated string of domains (eg bbc.co.uk, techcrunch.com, engadget.com) to restrict the search to."
+          },
+          "excludeDomains": {
+            "type": "string",
+            "description": "A comma-seperated string of domains (eg bbc.co.uk, techcrunch.com, engadget.com) to remove from the results."
+          },
+          "from": {
+            "type": "string",
+            "description": "A date and optional time for the oldest article allowed. This should be in ISO 8601 format (e.g. 2025-07-09 or 2025-07-09T09:28:11)"
+          },
+          "to": {
+            "type": "string",
+            "description": "A date and optional time for the newest article allowed. This should be in ISO 8601 format (e.g. 2025-07-09 or 2025-07-09T09:28:11)"
+          },
+          "language": {
+            "type": "string",
+            "description": "The 2-letter ISO-639-1 code of the language you want to get headlines for."
+          },
+          "sortBy": {
+            "type": "string",
+            "description": "The order to sort the articles in. Possible options: relevancy, popularity, publishedAt."
+          },
+          "pageSize": {
+            "type": "integer",
+            "description": "The number of results to return per page. Maximum: 100."
+          },
+          "page": {
+            "type": "integer",
+            "description": "Use this to page through the results."
+          }
+        },
+        "required": [
+          "q"
+        ]
+      },
+      "outputs": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "If the request was successful or not. Options: ok, error."
+          },
+          "totalResults": {
+            "type": "integer",
+            "description": "The total number of results available for your request."
+          },
+          "articles": {
+            "type": "array",
+            "description": "The results of the request.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "source": {
+                  "type": "object",
+                  "description": "The identifier id and a display name name for the source this article came from.",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "author": {
+                  "type": "string",
+                  "description": "The author of the article"
+                },
+                "title": {
+                  "type": "string",
+                  "description": "The headline or title of the article."
+                },
+                "description": {
+                  "type": "string",
+                  "description": "A description or snippet from the article."
+                },
+                "url": {
+                  "type": "string",
+                  "description": "The direct URL to the article."
+                },
+                "urlToImage": {
+                  "type": "string",
+                  "description": "The URL to a relevant image for the article."
+                },
+                "publishedAt": {
+                  "type": "string",
+                  "description": "The date and time that the article was published, in UTC (+000)"
+                },
+                "content": {
+                  "type": "string",
+                  "description": "The unformatted content of the article, where available. This is truncated to 200 chars."
+                }
+              },
+              "required": [
+                "title"
+              ]
+            }
+          }
+        }
+      },
+      "tool_provider": {
+        "provider_type": "http",
+        "url": "https://newsapi.org/v2/everything",
+        "http_method": "GET",
+        "content_type": "application/json",
+        "auth": {
+          "auth_type": "api_key",
+          "api_key": "$NEWS_API_KEY",
+          "var_name": "X-Api-Key"
+        }
+      }
+    },
+    {
+      "name": "top_headlines_get",
+      "description": "This endpoint provides live top and breaking headlines for a country, specific category in a country, single source, or multiple sources. You can also search with keywords. Articles are sorted by the earliest date published first. This endpoint is great for retrieving headlines for use with news tickers or similar.",
+      "tags": [
+        "articles"
+      ],
+      "inputs": {
+        "type": "object",
+        "properties": {
+          "country": {
+            "type": "string",
+            "description": "The 2-letter ISO 3166-1 code of the country you want to get headlines for. Note: you can't mix this param with the sources param."
+          },
+          "category": {
+            "type": "string",
+            "description": "The category you want to get headlines for. Possible options: business, entertainment, general, health, science, sports, technology. Note: you can't mix this param with the sources param."
+          },
+          "sources": {
+            "type": "string",
+            "description": "A comma-seperated string of identifiers for the news sources or blogs you want headlines from. Note: you can't mix this param with the country or category params."
+          },
+          "q": {
+            "type": "string",
+            "description": "Keywords or a phrase to search for."
+          },
+          "pageSize": {
+            "type": "integer",
+            "description": "The number of results to return per page (request). 20 is the default, 100 is the maximum."
+          },
+          "page": {
+            "type": "integer",
+            "description": "Use this to page through the results if the total results found is greater than the page size."
+          }
+        }
+      },
+      "outputs": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "If the request was successful or not. Options: ok, error."
+          },
+          "totalResults": {
+            "type": "integer",
+            "description": "The total number of results available for your request."
+          },
+          "articles": {
+            "type": "array",
+            "description": "The results of the request.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "source": {
+                  "type": "object",
+                  "description": "The identifier id and a display name name for the source this article came from.",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "author": {
+                  "type": "string",
+                  "description": "The author of the article"
+                },
+                "title": {
+                  "type": "string",
+                  "description": "The headline or title of the article."
+                },
+                "description": {
+                  "type": "string",
+                  "description": "A description or snippet from the article."
+                },
+                "url": {
+                  "type": "string",
+                  "description": "The direct URL to the article."
+                },
+                "urlToImage": {
+                  "type": "string",
+                  "description": "The URL to a relevant image for the article."
+                },
+                "publishedAt": {
+                  "type": "string",
+                  "description": "The date and time that the article was published, in UTC (+000)"
+                },
+                "content": {
+                  "type": "string",
+                  "description": "The unformatted content of the article, where available. This is truncated to 200 chars."
+                }
+              },
+              "required": [
+                "title"
+              ]
+            }
+          }
+        }
+      },
+      "tool_provider": {
+        "provider_type": "http",
+        "url": "https://newsapi.org/v2/top-headlines",
+        "http_method": "GET",
+        "content_type": "application/json",
+        "auth": {
+          "auth_type": "api_key",
+          "api_key": "$NEWS_API_KEY",
+          "var_name": "X-Api-Key"
+        }
+      }
+    }
+  ]
+}

--- a/static/providers.json
+++ b/static/providers.json
@@ -1,0 +1,21 @@
+[
+    {
+        "name": "openlibrary",
+        "provider_type": "http",
+        "http_method": "GET",
+        "url": "https://openlibrary.org/static/openapi.json",
+        "content_type": "application/json"
+    },
+    {
+        "name": "newsapi",
+        "provider_type": "text",
+        "file_path": "./newsapi_manual.json"
+    },
+    {
+        "name": "openai",
+        "provider_type": "http",
+        "http_method": "GET",
+        "url": "https://raw.githubusercontent.com/openai/openai-openapi/refs/heads/manual_spec/openapi.yaml",
+        "content_type": "application/x-yaml"
+    }
+]


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added a new Provider Registry page to browse available UTCP providers and set up an about page redirect for easier navigation.

- **New Features**
  - Created a searchable registry page at /registry that lists providers from providers.json, with details, copy, and download options.
  - Added a redirect from /about to /about/about-us for improved routing.
  - Included new provider manual and registry data files.
  - Added zod as a dependency.

<!-- End of auto-generated description by cubic. -->

