### PR TITLE
update method name and import paths

### DIFF
--- a/docs/for-tool-callers/for-tool-callers.md
+++ b/docs/for-tool-callers/for-tool-callers.md
@@ -23,8 +23,8 @@ The `utcp` package provides a ready-to-use client for discovering and calling to
 
 ```python
 import asyncio
-from utcp import UtcpClient
-from utcp.models import Provider
+from utcp.client.utcp_client import UtcpClient
+from utcp.shared.provider import HttpProvider
 
 async def main():
     # Create a UTCP client
@@ -163,7 +163,7 @@ When you register a provider with the `UtcpClient`, you are registering a **manu
 The UTCP client supports various authentication methods through provider configuration:
 
 ```python
-from utcp import UtcpClient
+from utcp.client.utcp_client import UtcpClient
 from utcp.shared.provider import HttpProvider
 
 client = UtcpClient()
@@ -207,7 +207,7 @@ For more complex applications, you can configure the `UtcpClient` using a config
 You can initialize the client by passing configuration parameters directly:
 
 ```python
-from utcp import UtcpClient
+from utcp.client.utcp_client import UtcpClient
 
 # Initialize client with configuration parameters
 client = await UtcpClient.create(

--- a/docs/for-tool-callers/tool-repository.md
+++ b/docs/for-tool-callers/tool-repository.md
@@ -73,7 +73,7 @@ class JsonFileToolRepository(ToolRepository):
 You can then instruct the `UtcpClient` to use your custom repository during instantiation:
 
 ```python
-from utcp.client import UtcpClient
+from utcp.client.utcp_client import UtcpClient
 
 # Instantiate your custom repository
 json_repo = JsonFileToolRepository("my_tools.json")

--- a/docs/index.md
+++ b/docs/index.md
@@ -108,7 +108,7 @@ async def main():
     )
 
     # Register tools from the manual provider
-    tools = await client.register_manual_provider(manual_provider)
+    tools = await client.register_tool_provider(manual_provider)
     print(f"Registered {len(tools)} tools from {manual_provider.name}")
 
     # Call a tool by its namespaced name: {provider_name}.{tool_name}


### PR DESCRIPTION
This PR updates method names and import paths across multiple files to reflect the latest utcp module structure and naming conventions.

Changes

/homepage

Replaced:
tools = await client.register_manual_provider(manual_provider)

with:
tools = await client.register_tool_provider(manual_provider)

/docs/for-tool-callers

Replaced:
from utcp import UtcpClient

with:
from utcp.client.utcp_client import UtcpClient

Replaced:
from utcp.models import Provider

with:
from utcp.shared.provider import HttpProvider

/for-tool-callers/tool-repository

Removed:
from utcp.client import UtcpClient

Added:
from utcp.client.utcp_client import UtcpClient

Notes

Method register_manual_provider has been renamed to register_tool_provider

Import paths were updated to reflect the internal restructuring of the utcp package


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated method names and import paths in documentation to match the latest utcp module structure and naming.

- **Docs**
  - Changed register_manual_provider to register_tool_provider.
  - Updated UtcpClient and Provider import paths to new locations.

<!-- End of auto-generated description by cubic. -->

