### PR TITLE
Update hall of fame github action

### DIFF
--- a/hall-of-fame-docs.md
+++ b/hall-of-fame-docs.md
@@ -67,7 +67,7 @@ The generated `src/data/contributors.json` file contains:
   "total_contributions": 1500,
   "total_impact_score": 3250,
   "total_recent_activity": 145,
-  "scoring_method": "hybrid_impact_score",
+  "scoring_method": "simplified_recent_activity",
   "contributors": [
     {
       "id": 123456,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Update the contributors workflow to use a dedicated token with contents: write and to run only on schedule or manual trigger. This makes the job reliable and avoids unnecessary runs.

- **Refactors**
  - Removed push trigger; kept cron and workflow_dispatch.
  - Added job permissions: contents: write.
  - Checkout uses secrets.UPDATE_HALL_OF_FAME, falling back to GITHUB_TOKEN.

<!-- End of auto-generated description by cubic. -->

