### PR TITLE
fixed Thanos badge "Open to Work"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3818,7 +3818,6 @@
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-3.8.1.tgz",
       "integrity": "sha512-IWYqjyTPjkNnHsFFu9+4YkeXS7PD1xI3Bn2shOhBq+f95mgDfWInkpfBN4aYvx4fTT67Am6cPtohRdwh4Tidtg==",
-      "license": "MIT",
       "dependencies": {
         "@docusaurus/core": "3.8.1",
         "@docusaurus/module-type-aliases": "3.8.1",

--- a/src/pages/hall-of-fame.tsx
+++ b/src/pages/hall-of-fame.tsx
@@ -15,6 +15,7 @@ const SPECIAL_CONTRIBUTORS = {
   FOUNDING: ['h3xxit', 'AndreiGS', 'edujuan', 'aliraza1006', 'ulughbeck'] as readonly string[],
   ADMINS: ['h3xxit', 'aliraza1006', 'edujuan', 'ulughbeck', 'AndreiGS'] as readonly string[],
   LEAD_DEVELOPER: 'Raezil',
+  OPEN_TO_WORK: ['raezil'] as readonly string[], // Only people who have explicitly told us they're open to work (Kamil Mosciszko = Raezil)
 } as const;
 
 // Simple tooltip component with dynamic positioning to prevent edge cutoff
@@ -237,7 +238,7 @@ const transformContributor = (ghContributor: GitHubContributor): DisplayContribu
     topContribution,
     recentActivity,
     qualityMetrics,
-    lookingForJob: ghContributor?.hireable || false,
+    lookingForJob: SPECIAL_CONTRIBUTORS.OPEN_TO_WORK.includes(login.toLowerCase()),
     repositories,
     total_recent_commits,
     // Enhanced line change statistics


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed the “Open to Work” badge on Hall of Fame so it only shows for contributors who explicitly opt in. Replaced the GitHub “hireable” flag with an allowlist in SPECIAL_CONTRIBUTORS.

- **Bug Fixes**
  - lookingForJob now checks SPECIAL_CONTRIBUTORS.OPEN_TO_WORK.includes(login.toLowerCase()) to ensure accurate badge display.

<sup>Written for commit c41816eca2b3e62f6eae0eff4f85ceeb7924ace6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

