### PR TITLE
docs: specify forward compatibility for unknown call template types, unknown keys and x- extensions

### DIFF
--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -178,6 +178,54 @@ Variables in call templates are replaced with actual values using two different 
 
 For example, `https://api.example.com/users/{user_id}` uses the `user_id` tool argument, while `${API_KEY}` references a configuration or environment variable.
 
+### Forward Compatibility
+
+A manual outlives the client that reads it. Providers add tools on new protocols, and
+later specification versions add keys. A client MUST keep a manual usable when it meets
+either.
+
+#### Unknown `call_template_type`
+
+When a tool's `tool_call_template.call_template_type` names a protocol the client has no
+handler for, the client MUST:
+
+1. **Skip that tool** — do not register it and do not offer it to the agent.
+2. **Warn**, naming the tool and the unrecognised type.
+3. **Register every other tool** in the manual normally.
+
+Rejecting the whole manual is not conformant. Under that behaviour, a provider that adds
+one tool on a new protocol withdraws every tool it already published from every client
+that has not installed the plugin yet — so the ecosystem cannot adopt a new protocol
+without a flag day.
+
+#### Unknown keys
+
+Manuals, tools and call templates are **open objects**. A client that reads a key it does
+not know MUST ignore that key for its own behaviour and MUST NOT reject the object that
+carries it. A client that writes a manual back out SHOULD preserve the unknown keys it
+read, so a manual survives a load/store round trip through a client that is older than the
+manual.
+
+#### Extension keys
+
+Keys beginning with `x-` are reserved for implementations. An `x-` key carries data for one
+implementation and never changes the meaning of the standard keys beside it, so a tool that
+carries one stays callable by clients that ignore it:
+
+```json
+{
+  "call_template_type": "http",
+  "url": "https://api.example.com/lists/{list_id}/commit",
+  "http_method": "POST",
+  "x-acme-retry": {"attempts": 3}
+}
+```
+
+Put an extension in an `x-` key, never in a new `call_template_type`: a custom
+`call_template_type` costs the tool its standard callers, an `x-` key costs nothing. Names
+without an `x-` prefix are reserved for this specification; to have a field standardised,
+open an [RFC](/about/RFC).
+
 ## Tool Provider Implementation
 
 ### Manual Structure
@@ -306,6 +354,11 @@ Example custom protocol structure:
   "timeout": 30
 }
 ```
+
+A manual containing such a tool stays loadable by clients without the plugin: they skip the
+one tool and register the rest, per [Forward Compatibility](#forward-compatibility). Use a
+custom `call_template_type` for a genuinely new transport; to add data to an existing
+transport, use an `x-` key instead.
 
 ### Custom Tool Repositories
 


### PR DESCRIPTION
The specification does not say what a client must do with content it does not
recognise. `docs/implementation.md` tells providers how to add a custom protocol
("Define Call Template, Implement Communication Handler, Register Protocol") but
never says what happens on the reading side when the plugin is absent. This PR
fills that gap with three rules: skip the unloadable tool, ignore unknown keys,
and reserve `x-` for implementations.

**Why this matters more than a documentation tidy-up.** The reference client
currently reads that silence as "reject everything". Measured against
`python-utcp` at `89a9832` (`utcp` 1.1.3, `utcp-http` 1.1.11, `utcp-text` 1.1.0):

* A manual holding one `http` tool and one tool with an unregistered
  `call_template_type` registers **zero** tools.
  `CallTemplateSerializer.validate_dict` raises `ValueError("Invalid call
  template type: ...")` for the one tool, and that failure propagates out of
  `UtcpManual.validate_tools` and takes the valid tool with it.
* A manual carrying the `info` key — **the key this repository's own
  `docs/implementation.md` puts in its first example manual, lines 31–34** —
  fails to load: `TypeError: UtcpManual.__init__() got an unexpected keyword
  argument 'info'`. The documented example is not loadable by the reference
  implementation.
* An `x-` key on an `http` call template loads, but is dropped. A client that
  reads and rewrites a manual erases the extension.

The consequence for the ecosystem is a flag day: a provider who adds one tool on
a new protocol withdraws every tool it already published from every client that
has not installed that plugin yet. Providers therefore cannot adopt a new
protocol incrementally, which is the opposite of what the plugin architecture is
for.

### The spec change

Adds `### Forward Compatibility` to `docs/implementation.md` (under Core
Concepts, after Variable Substitution) and one cross-reference from the existing
"Custom Protocol Plugins" section. Only `docs/` is touched; `versioned_docs/` are
frozen snapshots of released versions.

### Companion implementation

A companion PR against `python-utcp` implements these rules and adds tests:
universal-tool-calling-protocol/python-utcp#99

Happy to adjust the wording, or to take this to Discord first if the maintainers
would rather settle the rule there.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9PKfvS16TzzLUHi3xPUV4
