### PR TITLE
docs: document the client-enforced trust boundary and current OAuth2/SSE behavior

### DIFF
--- a/docs/protocols/http.md
+++ b/docs/protocols/http.md
@@ -211,12 +211,14 @@ HTTP responses are processed based on:
 ### HTTPS Enforcement
 The HTTP protocol enforces secure connections by only allowing:
 - HTTPS URLs (`https://`)
-- Localhost URLs (`http://localhost` or `http://127.0.0.1`)
+- Plain HTTP to a literal loopback address (`localhost`, `127.0.0.0/8`, `::1`, and their wildcard and IPv4-mapped forms)
 
-Any other HTTP URLs will be rejected with a security error to prevent man-in-the-middle attacks.
+Any other HTTP URL is rejected with a security error to prevent man-in-the-middle attacks. The rule applies to manual discovery, tool invocation and OAuth2 token endpoints alike, and every redirect hop is re-validated, with credentials not forwarded across origins.
+
+The loopback allowance exists for local development, so it is not extended to remote content: a manual or OpenAPI specification discovered from a non-loopback origin may not declare loopback tool URLs. Whether discovery counts as local is decided by the final origin after redirects.
 
 ### OAuth2 Token Caching
-OAuth2 tokens are automatically cached by `client_id` to avoid repeated authentication requests. The protocol supports both:
+OAuth2 tokens are cached per full credential configuration (token URL, client id, secret and scope) to avoid repeated authentication requests; two templates that share only a `client_id` never receive each other's tokens. The token endpoint is validated by the HTTPS enforcement rule before credentials are sent. The protocol supports both:
 - **Body credentials**: Client ID/secret in request body
 - **Header credentials**: Client ID/secret as Basic Auth header
 

--- a/docs/protocols/mcp.md
+++ b/docs/protocols/mcp.md
@@ -230,10 +230,10 @@ The implementation intelligently processes MCP responses:
 ```
 
 ### Security Features
-- **OAuth2 token caching**: Tokens cached by client_id to avoid repeated requests
+- **OAuth2 client-credentials flow**: The manual-level `auth` is applied to HTTP-based servers as the connection's bearer credential, unless the server entry already carries its own (`auth_token` or an `Authorization` header). The token endpoint must be HTTPS or a literal loopback address, redirects from it are refused, and the returned `access_token` must be a non-empty string of visible ASCII. Tokens are cached per full credential configuration (token URL, client id, secret, scope), never shared between manuals that merely share a client id, and concurrent first-time requests share a single token fetch
 - **Session management**: Persistent sessions with automatic error recovery
 - **Environment variables**: Use `${VAR_NAME}` syntax for sensitive credentials
-- **Transport security**: stdio inherits process security, HTTP supports OAuth2
+- **Transport security**: stdio inherits process security. HTTP and WebSocket server URLs are validated before any connection is made: HTTPS/WSS anywhere, plain HTTP/WS only to a literal loopback address. Sessions are isolated per server configuration and credentials, so two manuals that name a server the same but point at different configurations never share a session
 
 ## Error Handling
 

--- a/docs/protocols/sse.md
+++ b/docs/protocols/sse.md
@@ -331,7 +331,7 @@ data: {"message": "Simple data without event type"}
 | Clean End of Stream | The server closes the stream normally | The tool call completes; never triggers a reconnect |
 | Parse Error | Event `data` is not valid JSON | Yielded as a raw string |
 | Authentication Failed | HTTP 401/403 response | Raised immediately |
-| Server Error | HTTP 4xx/5xx response | Raised immediately |
+| Other HTTP Error | Any other 4xx or 5xx response | Raised immediately |
 
 ## Best Practices
 
@@ -361,7 +361,7 @@ data: {"message": "Simple data without event type"}
 ```
 
 ### OAuth2 Token Management
-- **Automatic token caching**: Tokens cached by client_id
+- **Automatic token caching**: Tokens cached per full credential configuration
 - **Token refresh**: Automatic token refresh on expiration
 - **Client credentials flow**: Supports OAuth2 client credentials grant
 

--- a/docs/protocols/sse.md
+++ b/docs/protocols/sse.md
@@ -55,7 +55,7 @@ For detailed field specifications, examples, and validation rules, see:
 |-------|------|----------|-------------|
 | `call_template_type` | string | Yes | Always "sse" for SSE providers |
 | `url` | string | Yes | SSE endpoint URL with optional path parameters like `{stream_id}` |
-| `event_type` | string | No | Filter for specific event types (default: all events) |
+| `event_type` | string | No | Filter for specific event types (default: all events). Events without an `event:` field have the type `message` |
 | `reconnect` | boolean | No | Auto-reconnect on connection loss (default: true) |
 | `retry_timeout` | number | No | Retry timeout in milliseconds (default: 30000) |
 | `headers` | object | No | Static headers for the initial connection |
@@ -323,11 +323,15 @@ data: {"message": "Simple data without event type"}
 
 | Error Type | Description | Handling |
 |------------|-------------|----------|
-| Connection Failed | Cannot connect to SSE endpoint | Raise `SSEConnectionError` |
-| Stream Timeout | No events received within timeout | Return partial results |
-| Parse Error | Invalid SSE event format | Skip malformed events |
-| Authentication Failed | Invalid credentials | Raise `SSEAuthError` |
-| Server Error | HTTP 5xx response | Raise `SSEServerError` |
+| Connection Failed | Cannot connect to the SSE endpoint | Raised immediately, no retry |
+| Connection Lost | An established stream drops before the server ends it | If `reconnect` is true and the call sent no request body: wait `retry_timeout` ms (or the last `retry:` value sent by the server, capped at 60 s), reconnect with the `Last-Event-ID` header, up to 5 reconnects per call. A reconnect handshake that fails counts as one attempt and is retried. Calls with a `body_field` are never re-issued, since that could re-execute a non-idempotent tool. Otherwise raised |
+| Not an Event Stream | The server answers 200 with a Content-Type other than `text/event-stream` | Raised immediately, never retried |
+| Handshake Stalled | The server accepts the connection but never sends response headers | Raised after 30 s. Reading the stream itself is not time-limited |
+| Malformed Stream | An event exceeds 16 MiB without a blank-line delimiter | Raised immediately, never retried |
+| Clean End of Stream | The server closes the stream normally | The tool call completes; never triggers a reconnect |
+| Parse Error | Event `data` is not valid JSON | Yielded as a raw string |
+| Authentication Failed | HTTP 401/403 response | Raised immediately |
+| Server Error | HTTP 4xx/5xx response | Raised immediately |
 
 ## Best Practices
 
@@ -394,10 +398,10 @@ data: {"message": "Simple data without event type"}
 The SSE protocol implementation provides:
 
 - **Async streaming**: Real-time event processing with async generators
-- **Automatic reconnection**: Configurable via `reconnect` and `retry_timeout` fields
+- **Automatic reconnection**: When `reconnect` is true and an established stream drops, the client waits `retry_timeout` ms (overridden by any `retry:` field the server sent, capped at 60 s), reconnects with the `Last-Event-ID` header so the server can resume, and gives up after 5 reconnects per call; a reconnect handshake that fails counts as an attempt and is retried. A clean end of stream completes the call, and connection or HTTP errors on the initial request fail immediately. The handshake itself is limited to 30 s so a silent server cannot hang a call
 - **Event filtering**: Client-side filtering by `event_type`
-- **Authentication caching**: OAuth2 tokens cached by client_id
-- **Security enforcement**: HTTPS or localhost connections only
+- **Authentication caching**: OAuth2 tokens cached per full credential configuration
+- **Security enforcement**: HTTPS or loopback connections only; a remote manual may not target loopback tool URLs
 - **Error handling**: Graceful handling of connection failures and retries
 
 ### Usage Example

--- a/docs/protocols/streamable-http.md
+++ b/docs/protocols/streamable-http.md
@@ -138,13 +138,13 @@ Authentication and header values support environment variable substitution:
 ## Security Considerations
 
 ### Connection Security
-- **HTTPS enforcement**: Only HTTPS URLs or localhost connections are allowed
+- **HTTPS enforcement**: Only HTTPS URLs or literal loopback connections are allowed, for manual discovery, tool invocation and OAuth2 token endpoints alike, and redirects are never followed unchecked (re-validated per hop, or refused). A manual discovered from a non-loopback origin may not declare loopback tool URLs
 - **Certificate validation**: SSL certificates are validated by default
 - **Secure token handling**: OAuth2 tokens are cached securely
 
 ### Authentication Security
 - **Environment variables**: Use `${VAR_NAME}` syntax for sensitive credentials
-- **Token caching**: OAuth2 tokens are cached by client_id to avoid repeated requests
+- **Token caching**: OAuth2 tokens are cached per full credential configuration (token URL, client id, secret, scope), never by client id alone
 - **Authentication methods**: Support for API key, Basic auth, and OAuth2
 - **Location flexibility**: API keys can be sent in headers, query params, or cookies
 - **URL encoding**: Path parameters are properly URL-encoded to prevent injection
@@ -232,8 +232,8 @@ The Streamable HTTP protocol implementation provides:
 
 - **Chunked streaming**: Processes responses in configurable chunk sizes
 - **Content-type awareness**: Different handling for JSON, NDJSON, and binary content
-- **Authentication caching**: OAuth2 tokens cached by client_id
-- **Security enforcement**: HTTPS or localhost connections only
+- **Authentication caching**: OAuth2 tokens cached per full credential configuration
+- **Security enforcement**: HTTPS or loopback connections only; a remote manual may not target loopback tool URLs
 - **Error handling**: Graceful handling of connection failures and timeouts
 - **Resource management**: Proper cleanup of HTTP connections and sessions
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -99,7 +99,7 @@ Secure your UTCP manual endpoints:
 
 Reference clients enforce these rules regardless of configuration; design tools and manuals against them:
 
-- **Allowed destinations**: every URL a client connects to (manual discovery, tool invocation, OAuth2 token endpoints, MCP server URLs) must use HTTPS/WSS, or plain HTTP/WS to a literal loopback address only. Plain HTTP to any other host is rejected.
+- **Allowed destinations**: every URL a client connects to (manual discovery, tool invocation, OAuth2 token endpoints, MCP server URLs) must use HTTPS/WSS, or plain HTTP/WS to a literal loopback address only. Plain HTTP/WS to any other host is rejected.
 - **Redirects**: each hop is re-validated against the same rule, and credentials (auth headers, cookies, query keys, request bodies) are not forwarded across origins.
 - **No redirection at loopback**: a manual or OpenAPI specification discovered from a non-loopback origin may not declare tool or server URLs on the loopback interface. The local-development exemption is decided by the final origin after redirects, so a loopback URL that redirects to a remote origin does not keep it.
 - **OAuth2 token endpoints**: validated by the destination rule before any credentials are sent, with redirects handled under the same rule; tokens are cached per full credential configuration and never shared between configurations that only share a client id.

--- a/docs/security.md
+++ b/docs/security.md
@@ -95,6 +95,16 @@ Secure your UTCP manual endpoints:
 
 ## Protocol-Specific Security
 
+### Client-Enforced Trust Boundary
+
+Reference clients enforce these rules regardless of configuration; design tools and manuals against them:
+
+- **Allowed destinations**: every URL a client connects to (manual discovery, tool invocation, OAuth2 token endpoints, MCP server URLs) must use HTTPS/WSS, or plain HTTP/WS to a literal loopback address only. Plain HTTP to any other host is rejected.
+- **Redirects**: each hop is re-validated against the same rule, and credentials (auth headers, cookies, query keys, request bodies) are not forwarded across origins.
+- **No redirection at loopback**: a manual or OpenAPI specification discovered from a non-loopback origin may not declare tool or server URLs on the loopback interface. The local-development exemption is decided by the final origin after redirects, so a loopback URL that redirects to a remote origin does not keep it.
+- **OAuth2 token endpoints**: validated by the destination rule before any credentials are sent, with redirects handled under the same rule; tokens are cached per full credential configuration and never shared between configurations that only share a client id.
+- **MCP**: manual-level OAuth2 is applied as the bearer credential for HTTP-based servers unless the server entry carries its own; redirects from the token endpoint are refused and the returned `access_token` must be a non-empty string of visible ASCII; sessions are isolated per server configuration and credentials.
+
 ### HTTP/HTTPS Security
 
 **Required configurations:**
@@ -230,6 +240,7 @@ CLI execution poses significant security risks. Use with extreme caution.
 
 **Security considerations:**
 - ✅ Use trusted MCP server implementations
+- ✅ Server URLs are validated: HTTPS/WSS anywhere, plain HTTP/WS to loopback only
 - ✅ Sandbox MCP server processes
 - ✅ Limit server resource usage
 - ✅ Monitor server health and logs
@@ -403,11 +414,11 @@ Implement automated security validation:
 
 ### Protocol-Specific Security
 
-- [ ] **HTTP**: HTTPS only, certificate validation
+- [ ] **HTTP**: HTTPS or loopback only, certificate validation; remote manuals cannot target loopback
 - [ ] **CLI**: Sandboxed execution, input sanitization
 - [ ] **SSE**: Authenticated connections, event limits
 - [ ] **Text**: Path validation, size limits
-- [ ] **MCP**: Trusted servers, resource limits
+- [ ] **MCP**: Trusted servers, HTTPS/loopback-only server URLs, resource limits
 
 By following these security guidelines, you can safely implement UTCP while maintaining strong security posture across all communication protocols.
 


### PR DESCRIPTION
Brings the hand-written protocol docs in line with what utcp-http 1.1.12 / utcp-mcp 1.1.3 and the matching TypeScript releases (@utcp/http 1.1.12, @utcp/mcp 1.1.7) actually enforce. The generated `docs/api` tree was synced automatically by python-utcp's workflow after the release merge and is not touched here.

**security.md** — new *Client-Enforced Trust Boundary* subsection: HTTPS/WSS or literal-loopback-only destinations for discovery, invocation, OAuth2 token endpoints and MCP server URLs; redirects never followed unchecked and credentials not forwarded cross-origin; a manual or OpenAPI spec discovered from a non-loopback origin may not declare loopback tool/server URLs (decided by the final post-redirect origin); OAuth2 tokens cached per full credential configuration; MCP credential and session isolation. Checklist entries updated to match.

**http.md** — loopback allowance described accurately (full loopback set, not just localhost), the remote-manual loopback rule and redirect handling added, OAuth2 cache described as per full credential configuration rather than by `client_id`.

**mcp.md** — OAuth2 is now actually applied to HTTP-based servers (previously accepted on the template but unused), with token-endpoint validation, redirect refusal, token validation and per-configuration caching; HTTP/WS server URLs validated before connecting; sessions isolated per configuration and credentials.

**sse.md** — reconnection semantics (`Last-Event-ID` resume, `retry:` honored with a 60 s cap, 5 reconnects per call, calls that sent a body are never re-issued, 30 s handshake limit), the `message` default event type, and an accurate error-handling table.

**streamable-http.md / sse.md** — token-caching and security bullets corrected.

Notes for reviewers:
- Local `docusaurus build` compiles both server and client successfully but then fails on Windows with `EEXIST` writing `build/rfc/index.html` (redirect plugin vs. a real page). This reproduces on a clean build and `main` deploys green in CI, so it is a pre-existing Windows-only conflict unrelated to these files; the `test-deploy` run on this PR is the authoritative check.
- Two pre-existing broken anchors noticed while editing, not fixed here: `security.md` links to `sse.md#security-considerations` and `mcp.md#security-considerations`, and neither doc has that heading.
- Deliberately not claimed for the HTTP-family protocols: token-shape validation (non-empty visible ASCII) exists only in the MCP plugin today. Worth porting for parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brings the hand-written protocol docs in line with what `utcp-http` 1.1.12 / `utcp-mcp` 1.1.3 and the matching TypeScript releases actually enforce. Docs previously said OAuth2 tokens were cached by `client_id` and only `localhost` was allowed; they now describe the real security boundary, redirect handling, and SSE reconnection semantics.

**Security model**
- New Client-Enforced Trust Boundary section: every destination must be HTTPS/WSS or a literal loopback address, redirects are re-validated per hop, and credentials are never forwarded across origins.
- A manual or OpenAPI spec discovered from a non-loopback origin cannot declare loopback tool or server URLs; the loopback decision uses the final post-redirect origin.
- OAuth2 tokens are cached per full credential configuration (token URL, client id, secret, scope), never shared between configs that merely share a client id.

**Behavior corrections**
- MCP manual-level OAuth2 is now applied to HTTP-based servers, with token-endpoint validation, redirect refusal, token shape validation, and per-config caching; HTTP/WS server URLs are validated before connecting and sessions are isolated per configuration and credentials.
- SSE docs now cover `Last-Event-ID` resume, `retry:` honoring capped at 60 s, 5 reconnects per call, no re-issue of calls that sent a body, a 30 s handshake limit, the `message` default event type, and an accurate error table.
- Local `docusaurus build` fails on Windows with `EEXIST` writing `build/rfc/index.html`; this reproduces on a clean build of `main`, so it is pre-existing and the `test-deploy` CI run is authoritative.
- Two pre-existing broken anchors in `security.md` are left unfixed, and token-shape validation remains documented for MCP only since the HTTP-family OAuth2 paths don't yet validate it.
- The HTTP-family per-config caching claim depends on `utcp-http` 1.1.13, so this PR should merge after that release ships.

<sup>Written for commit 034b5f026f3129a8d531c89b505f3abd168a92c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/universal-tool-calling-protocol/utcp-specification/pull/65?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

